### PR TITLE
fix getting dynamic client ID by searching it in all provided assets

### DIFF
--- a/pkg/soundcloud/get_client_id.go
+++ b/pkg/soundcloud/get_client_id.go
@@ -2,7 +2,7 @@ package soundcloud
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"regexp"
 )
@@ -12,33 +12,58 @@ import (
 
 // GetClientID returns a new generated client_id when a request is made to SoundCloud's API
 func (s *Soundcloud) GetClientID() (string, error) {
-	var clientID string
-
-	// this is the JS file that is injected into the page source
-	// this can always change at some point, so we have to keep an eye on it
-	resp, err := s.Client.Get("https://a-v2.sndcdn.com/assets/2-fbfac8ab.js")
+	// Make the initial request to SoundCloud
+	resp, err := s.Client.Get("https://soundcloud.com")
 	if err != nil {
 		return "", err
 	}
-
 	defer resp.Body.Close()
 
-	body, err := ioutil.ReadAll(resp.Body)
+	// Read the response body
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		log.Fatalf("failed to read response body: %v", err)
+		return "", fmt.Errorf("failed to read response body: %v", err)
 	}
 
-	// regex to find the client_id
-	re := regexp.MustCompile(`client_id\s*:\s*['"]([^'"]+)['"]`)
-	matches := re.FindSubmatch(body)
+	// Compile regex to find asset URLs
+	assetre := regexp.MustCompile(`src="(https:\/\/a-v2\.sndcdn\.com\/assets\/[^\s"]+)"`)
+	assetMatches := assetre.FindAllSubmatch(body, -1)
 
-	if len(matches) > 1 {
-		// Found a client_id
-		clientID = string(matches[1])
-	} else {
-		log.Println("client_id not found")
-		return "", fmt.Errorf("client_id not found")
+	// Check if any asset matches were found
+	if len(assetMatches) == 0 {
+		return "", fmt.Errorf("asset not found")
 	}
-	
-	return clientID, nil
+
+	// Iterate over asset matches to find the client ID
+	for _, match := range assetMatches {
+		assetURL := string(match[1])
+
+		// Make a request to the asset URL
+		resp, err := s.Client.Get(assetURL)
+		if err != nil {
+			return "", err
+		}
+		defer resp.Body.Close()
+
+		// Read the response body
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			log.Fatalf("failed to read response body: %v", err)
+			return "", fmt.Errorf("failed to read response body: %v", err)
+		}
+
+		// Compile regex to find the client ID
+		re := regexp.MustCompile(`client_id:\"([^\"]+)\"`)
+		matches := re.FindSubmatch(body)
+
+		// Check if a client ID was found
+		if len(matches) > 1 {
+			return string(matches[1]), nil
+		}
+	}
+
+	// If no client ID was found
+	log.Println("client_id not found")
+	return "", fmt.Errorf("client_id not found")
 }


### PR DESCRIPTION
This PR dynamically get's the asset URL (which contains the client ID) from an additional initial GET request to soundcloud.com.

This fixes the currently happening "Error unmarshalling JSON: unexpected end of JSON input", which basically is just an 401 unauthorized on the streamURL GET request.

